### PR TITLE
Project Setup Changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,13 @@ project (libblinkstick)
 
 option(BUILD_DOC "Build documentation" ON)
 
-find_package(PkgConfig REQUIRED)
-pkg_search_module(HIDAPI REQUIRED hidapi)
+if(WIN32)
+  list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+  find_package(HIDAPI REQUIRED)
+else(WIN32)
+  find_package(PkgConfig REQUIRED)
+  pkg_search_module(HIDAPI REQUIRED hidapi)
+endif(WIN32)
 
 include_directories(PUBLIC ${HIDAPI_INCLUDE_DIRS})
 
@@ -13,7 +18,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 
-set(COMMON_INCLUDES ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/seatest ${HIDAPI_INCLUDE_DIRS})
 if(BUILD_DOCS)
   find_package(Doxygen)
   if (DOXYGEN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,20 +14,22 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 
 set(COMMON_INCLUDES ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/seatest ${HIDAPI_INCLUDE_DIRS})
+if(BUILD_DOCS)
+  find_package(Doxygen)
+  if (DOXYGEN_FOUND)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    message("Doxygen found, setting build rules")
 
-find_package(Doxygen)
-if (DOXYGEN_FOUND)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-  message("Doxygen build started")
+    add_custom_target(docs
+    ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating API documentation with Doxygen" VERBATIM
+    )
+  else()
+    message("Doxygen needs to be installed to generate the doxygen documentation")
+  endif (DOXYGEN_FOUND)
+endif(BUILD_DOCS)
 
-  add_custom_target(docs
-  ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "Generating API documentation with Doxygen" VERBATIM
-  )
-else (DOXYGEN_FOUND)
-  message("Doxygen need to be installed to generate the doxygen documentation")
-endif (DOXYGEN_FOUND)
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")

--- a/cmake/FindHIDAPI.cmake
+++ b/cmake/FindHIDAPI.cmake
@@ -1,0 +1,46 @@
+# - try to find HIDAPI library
+# from http://www.signal11.us/oss/hidapi/
+#
+# Cache Variables: (probably not for direct use in your scripts)
+#  HIDAPI_INCLUDE_DIR
+#  HIDAPI_LIBRARY
+#
+# Non-cache variables you might use in your CMakeLists.txt:
+#  HIDAPI_FOUND
+#  HIDAPI_INCLUDE_DIRS
+#  HIDAPI_LIBRARIES
+#
+# Requires these CMake modules:
+#  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+find_library(HIDAPI_LIBRARY
+	NAMES hidapi hidapi-libusb)
+
+find_path(HIDAPI_INCLUDE_DIR
+	NAMES hidapi.h
+	PATH_SUFFIXES
+	hidapi)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HIDAPI
+	DEFAULT_MSG
+	HIDAPI_LIBRARY
+	HIDAPI_INCLUDE_DIR)
+
+if(HIDAPI_FOUND)
+	set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARY}")
+
+	set(HIDAPI_INCLUDE_DIRS "${HIDAPI_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(HIDAPI_INCLUDE_DIR HIDAPI_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,17 @@
-include_directories(${COMMON_INCLUDES})
+
 
 # LIBRARY
-add_library(libblinkstick libblinkstick.c)
-target_link_libraries(libblinkstick ${HIDAPI_LIBRARIES})
+add_library(libblinkstick libblinkstick.c libblinkstick.h)
+target_include_directories(libblinkstick 
+        PUBLIC
+          ${CMAKE_CURRENT_SOURCE_DIR}
+          ${HID_INCLUDE_DIRS})
+target_link_libraries(libblinkstick PUBLIC ${HIDAPI_LIBRARIES})
 set_target_properties(libblinkstick PROPERTIES OUTPUT_NAME blinkstick)
 
 # CLI TOOL
 add_executable(blinkstick blinkstick.c)
-target_link_libraries(blinkstick libblinkstick)
+target_link_libraries(blinkstick PUBLIC libblinkstick)
 
 install(TARGETS blinkstick libblinkstick
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"

--- a/src/blinkstick.c
+++ b/src/blinkstick.c
@@ -1,5 +1,13 @@
+#ifndef _WINDOWS
 #include <unistd.h>
+#endif
 #include "libblinkstick.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
 
 typedef struct arguments arguments;
 struct arguments;

--- a/src/libblinkstick.c
+++ b/src/libblinkstick.c
@@ -1,4 +1,9 @@
 #include "libblinkstick.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
 
 bool print_debug = false;
 

--- a/src/libblinkstick.h
+++ b/src/libblinkstick.h
@@ -1,9 +1,6 @@
+#pragma once
+
 #include <hidapi/hidapi.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
 
 /**
  * @file libblinkstick.h


### PR DESCRIPTION
## Fixed
* Linking to `hidapi` on windows.

## Changed
* The way `hidapi` is found on windows
* How directories are included for the `libblinkstick` project
* How libraries are linked to the `libblinkstick` project (more modern `target_link_libraries()` function)
* How the `libblinkstick` library is linked to the CLI. 

## Added
* New `FindHIDAPI.cmake` file taken from [here](https://github.com/rpavlik/cmake-modules/blob/master/FindHIDAPI.cmake). 