### PR TITLE
Add BlinkStick Pro Support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ set_target_properties(libblinkstick PROPERTIES OUTPUT_NAME blinkstick)
 # CLI TOOL
 add_executable(blinkstick blinkstick.c)
 target_link_libraries(blinkstick PUBLIC libblinkstick)
+add_dependencies(blinkstick libblinkstick)
 
 install(TARGETS blinkstick libblinkstick
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"

--- a/src/blinkstick.c
+++ b/src/blinkstick.c
@@ -18,6 +18,7 @@ struct arguments {
   int blue;
   int count;
   int index;
+  int channel;
 };
 
 void usage() {
@@ -27,6 +28,7 @@ OPTIONS\n\
   --color set the color using a three rgb values\n\
   --count set the number of blinkstick devices to address\n\
   --index which led should be set\n\
+  --channel which channel to use (BlinkStick Pro)\n\
   --debug turn on debug logging\n");
 }
 
@@ -44,6 +46,10 @@ struct arguments* parse_args(char** flags) {
       if (strcmp(flags[i], "--index") == 0) {
         args->index = atoi(*(flags + i + 1));
       }
+
+	  if (strcmp(flags[i], "--channel") == 0) {
+		  args->channel = atoi(*(flags + i + 1));
+	  }
 
       if (strcmp(flags[i], "--debug") == 0) {
         blinkstick_debug();
@@ -76,10 +82,14 @@ int main(int argc, char** argv) {
   blinkstick_device** devices = blinkstick_find_many(args->count);
 
   for (int j = 0; j < args->count; j++) {
-    blinkstick_set_color(devices[j], args->index, args->red, args->green,
+    // set the color
+    blinkstick_set_color(devices[j], args->channel, args->index, args->red, args->green,
                          args->blue);
+    // free the device
     blinkstick_destroy(devices[j]);
   }
 
+  // possibly unecessary, but good practice nonetheless. 
+  free(args);
   return 0;
 }

--- a/src/libblinkstick.h
+++ b/src/libblinkstick.h
@@ -20,6 +20,7 @@
 static int const BLINKSTICK_VENDOR_ID = 8352;    //"0X20A0";
 static int const BLINKSTICK_PRODUCT_ID = 16869;  //"0X41E5";
 
+static int const BLINKSTICK_MODE_MSG_SIZE = 2;
 static int const BLINKSTICK_SINGLE_LED_MSG_SIZE = 4;
 static int const BLINKSTICK_INDEXED_LED_MSG_PACKET_SIZE = 6;
 
@@ -30,6 +31,11 @@ static int const BLINKSTICK_INDEXED_LED_MSG_PACKET_SIZE = 6;
  * free it with blinkstick_destroy.
  */
 typedef struct blinkstick_device { hid_device* handle; } blinkstick_device;
+
+/**
+ * Possible blink stick modes (only valid for Blinkstick Pro).
+ */
+enum blinkstick_mode { normal =0, inverse =1, smart_pixel=2};
 
 /**
  * Given a count will return a pointer array of blinkstick
@@ -48,20 +54,30 @@ blinkstick_device* blinkstick_find();
  * Sets the LED at the given index to the specified color for the
  * provided device
  */
-void blinkstick_set_color(blinkstick_device* device,
-                          int index,
-                          int red,
-                          int green,
-                          int blue);
+void blinkstick_set_color(blinkstick_device* blinkstick,
+						  int channel,
+						  int index,
+						  int red,
+						  int green,
+						  int blue);
+/**
+ * Set the mode of the blinkstick. Possible modes are "normal" (non-inverse LED control), 
+ * "inverse" (LED values are inverted) and "smart" (LEDs are WS2812 smart LEDs). 
+ * Note that you'll need to implement a delay after setting the mode before setting the 
+ * color on the blinkstick device. 
+ */
+void blinkstick_set_mode(blinkstick_device* blinkstick, const enum blinkstick_mode mode);
 
 /**
  * Turns off the led at the specified index for the provided device.
  *
  * This is the same as using set_color with the RGB value (0, 0, 0)
  */
-void blinkstick_off(blinkstick_device* device, int index);
+void blinkstick_off(blinkstick_device* device, int channel, int index);
 
-// Turns on debug logging.
+/**
+ * Turns on debug logging. 
+ */
 void blinkstick_debug();
 
 /**


### PR DESCRIPTION
### Added
* `enum` for possible Blinkstick modes
* New function to set the mode of blinksticks

### Changes
* Updates to the `blinkstick_set_color` function to take into account the channel in addition to the index. 
* CLI inputs to take into account the channel. 
* Switched from `hid_write()` to `hid_set_feature_report()`. Code doesn't work otherwise with BlinkStick pro on windows 10. If this is Windows specific I can adjust the code to take this into account. 