### PR TITLE
Make CLI Build Optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 2.6)
 project (libblinkstick)
 
 option(BUILD_DOC "Build documentation" ON)
+option(BUILD_CLI "Build command line BlinkStick control program" ON)
 
 if(WIN32)
   list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
@@ -18,7 +19,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 
-if(BUILD_DOCS)
+if(BUILD_DOC)
   find_package(Doxygen)
   if (DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
@@ -32,7 +33,7 @@ if(BUILD_DOCS)
   else()
     message("Doxygen needs to be installed to generate the doxygen documentation")
   endif (DOXYGEN_FOUND)
-endif(BUILD_DOCS)
+endif(BUILD_DOC)
 
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required (VERSION 2.6)
 
 project (libblinkstick)
 
-option(BUILD_DOC "Build documentation" ON)
+option(BUILD_DOCS "Build documentation" ON)
 option(BUILD_CLI "Build command line BlinkStick control program" ON)
 
 if(WIN32)
@@ -19,7 +19,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/target)
 
-if(BUILD_DOC)
+if(BUILD_DOCS)
   find_package(Doxygen)
   if (DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
@@ -33,7 +33,7 @@ if(BUILD_DOC)
   else()
     message("Doxygen needs to be installed to generate the doxygen documentation")
   endif (DOXYGEN_FOUND)
-endif(BUILD_DOC)
+endif(BUILD_DOCS)
 
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,13 +9,21 @@ target_include_directories(libblinkstick
 target_link_libraries(libblinkstick PUBLIC ${HIDAPI_LIBRARIES})
 set_target_properties(libblinkstick PROPERTIES OUTPUT_NAME blinkstick)
 
-# CLI TOOL
-add_executable(blinkstick blinkstick.c)
-target_link_libraries(blinkstick PUBLIC libblinkstick)
-
-install(TARGETS blinkstick libblinkstick
+install(TARGETS libblinkstick
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
         LIBRARY DESTINATION "${INSTALL_LIB_DIR}")
-
+        
 install(FILES libblinkstick.h DESTINATION "${INSTALL_INC_DIR}")
+
+if(BUILD_CLI)
+    # CLI TOOL
+    add_executable(blinkstick blinkstick.c)
+    target_link_libraries(blinkstick PUBLIC libblinkstick)
+
+    install(TARGETS blinkstick
+            RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+            ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+            LIBRARY DESTINATION "${INSTALL_LIB_DIR}")
+endif(BUILD_CLI)
+


### PR DESCRIPTION
Add CMake option to make the CLI optional. Fixed if() statement for building documentation.

Resolves #20.