### PR TITLE
Feature/cmake export config version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,4 +47,9 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/libblinkstick.pc.in
 
 install(FILES ${CMAKE_BINARY_DIR}/libblinkstick.pc DESTINATION "${INSTALL_PKGCONFIG_DIR}")
 
+set(libblinkstick_VERSION_MAJOR 1)
+set(libblinkstick_VERSION_MINOR 0)
+set(libblinkstick_VERSION_PATCH 0)
+
+set(libblinkstick_VERSION "${libblinkstick_VERSION_MAJOR}.${libblinkstick_VERSION_MINOR}.${libblinkstick_VERSION_PATCH}")
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation
 set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/libblinkstick.pc.in
-		${CMAKE_CURRENT_BINARY_DIR}/libblinkstick.pc @ONLY)
+		${CMAKE_BINARY_DIR}/libblinkstick.pc @ONLY)
 
-install(FILES libblinkstick.pc DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+install(FILES ${CMAKE_BINARY_DIR}/libblinkstick.pc DESTINATION "${INSTALL_PKGCONFIG_DIR}")
 
 add_subdirectory(src)

--- a/cmake/libblinkstickConfig.cmake.in
+++ b/cmake/libblinkstickConfig.cmake.in
@@ -1,0 +1,4 @@
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/libblinkstickTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,27 +2,66 @@
 add_library(libblinkstick libblinkstick.c libblinkstick.h)
 target_include_directories(libblinkstick
         PUBLIC
-          ${CMAKE_CURRENT_SOURCE_DIR}
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+          $<INSTALL_INTERFACE:include>
           ${HIDAPI_INCLUDE_DIR})
+
 target_link_libraries(libblinkstick PUBLIC ${HIDAPI_LIBRARY})
 set_target_properties(libblinkstick PROPERTIES OUTPUT_NAME blinkstick)
 set_property(TARGET libblinkstick PROPERTY C_STANDARD 11)
 
-install(TARGETS libblinkstick
+install(TARGETS libblinkstick EXPORT libblinkstickTargets
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
         LIBRARY DESTINATION "${INSTALL_LIB_DIR}")
 
 install(FILES libblinkstick.h DESTINATION "${INSTALL_INC_DIR}")
 
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+        "${CMAKE_BINARY_DIR}/libblinkstick/libblinkstickConfigVersion.cmake"
+        VERSION ${libblinkstick_VERSION}
+        COMPATIBILITY AnyNewerVersion
+)
+
 if(BUILD_CLI)
     # CLI TOOL
-    add_executable(blinkstick blinkstick.c)
-    add_dependencies(blinkstick libblinkstick)
-    target_link_libraries(blinkstick PUBLIC libblinkstick)
+    set(cli_tool_name blinkstick-cli)
+    add_executable(${cli_tool_name} blinkstick.c)
+    add_dependencies(${cli_tool_name} libblinkstick)
+    target_link_libraries(${cli_tool_name} PUBLIC libblinkstick)
+    set_target_properties(${cli_tool_name} PROPERTIES OUPUT_NAME blinkstick)
 
-    install(TARGETS blinkstick
+    install(TARGETS ${cli_tool_name} EXPORT libblinkstickTargets
             RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
             ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
             LIBRARY DESTINATION "${INSTALL_LIB_DIR}")
 endif(BUILD_CLI)
+
+export(EXPORT 
+            libblinkstickTargets 
+       FILE 
+            "${CMAKE_BINARY_DIR}/libblinkstick/libblinkstickTargets.cmake")
+
+configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/cmake/libblinkstickConfig.cmake.in # input
+        ${CMAKE_BINARY_DIR}/libblinkstick/libblinkstickConfig.cmake # output
+        INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake)
+
+install(EXPORT 
+            libblinkstickTargets
+        FILE 
+            libblinkstickTargets.cmake
+        DESTINATION 
+            cmake)
+
+install(FILES
+            "${CMAKE_BINARY_DIR}/libblinkstick/libblinkstickConfig.cmake"
+            "${CMAKE_BINARY_DIR}/libblinkstick/libblinkstickConfigVersion.cmake"
+        DESTINATION
+                cmake
+        COMPONENT
+                Devel)
+
+        


### PR DESCRIPTION
## Fixed
* Issue installing `libblinkstick.pc` when building the `INSTALL` cmake target

## Added 
* CMake export code to allow other cmake projects easily include `libblinkstick` (#30)
* Version number for library (#27)