### PR TITLE
Fix color index for Blinkstick Strip

### DIFF
--- a/src/libblinkstick.c
+++ b/src/libblinkstick.c
@@ -260,9 +260,9 @@ blinkstick_color* blinkstick_get_color(struct blinkstick_device* blinkstick, con
 		}
 		else
 		{
-			color->red = data[index * 3 + 1];
-			color->green = data[index * 3 + 3];
-			color->blue = data[index * 3 + 2];
+			color->red = data[index * 3 + 3];
+			color->green = data[index * 3 + 2];
+			color->blue = data[index * 3 + 4];
 		}
 		// free memory
 		free(data);


### PR DESCRIPTION
blinkstick_get_color() returns wrong values with non-zero index on Blinkstick Strip. The issue was solved by shifting the indices to data buffer. 

This is tested only with Blinkstick Strip on Ubuntu 16.04. I haven't read any documents or specification of Blinkstick.  