### PR TITLE
Fix argument parsing loop

### DIFF
--- a/src/blinkstick.c
+++ b/src/blinkstick.c
@@ -32,12 +32,12 @@ OPTIONS\n\
   --debug turn on debug logging\n");
 }
 
-struct arguments* parse_args(char** flags) {
+struct arguments* parse_args(int argc, char** flags) {
   struct arguments* args = malloc(sizeof(arguments));
   args->count = 1;
   int color_set = 0;
 
-  for (int i = 1; i < sizeof(flags); i++) {
+  for (int i = 1; i < argc; i++) {
     if (flags[i] != NULL) {
       if (strcmp(flags[i], "--count") == 0) {
         args->count = atoi(*(flags + i + 1));
@@ -78,7 +78,7 @@ struct arguments* parse_args(char** flags) {
 }
 
 int main(int argc, char** argv) {
-  struct arguments* args = parse_args(argv);
+  struct arguments* args = parse_args(argc, argv);
   blinkstick_device** devices = blinkstick_find_many(args->count);
 
   for (int j = 0; j < args->count; j++) {


### PR DESCRIPTION
This PR addresses a parsing issue in parse_args where sizeof(flags) was used incorrectly as the loop boundary. This resulted in partial or incorrect argument parsing, This value does not accurately represent the number of command-line arguments (argc) but rather the size of the pointer itself. 

On 32-bit systems, sizeof(flags) evaluates to 4, on 64 bits systems it evaluates to 8.

I've found this issue on a 32 bit system where my last arguments (index) was being ignored, which made me start to debug the issue.

This PR should fix the issue.